### PR TITLE
fix(db): error when creating new empty database

### DIFF
--- a/.erb/configs/webpack.config.main.prod.ts
+++ b/.erb/configs/webpack.config.main.prod.ts
@@ -39,6 +39,9 @@ const configuration: webpack.Configuration = {
     minimizer: [
       new TerserPlugin({
         parallel: true,
+        terserOptions: {
+          keep_classnames: /([A-Za-z]+)(\d{13})/,
+        },
       }),
     ],
   },

--- a/src/db/migrations/1709996613941-CreateDatabase.ts
+++ b/src/db/migrations/1709996613941-CreateDatabase.ts
@@ -1,0 +1,44 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class CreateDatabase1709996613942 implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    const tagTable = await queryRunner.getTable('tag');
+    if (!tagTable) {
+      await queryRunner.query(
+        `CREATE TABLE "tag" ("id" integer PRIMARY KEY AUTOINCREMENT NOT NULL, "name" varchar NOT NULL)`,
+      );
+    }
+    const projectTable = await queryRunner.getTable('project');
+    if (!projectTable) {
+      await queryRunner.query(
+        `CREATE TABLE "project" ("id" integer PRIMARY KEY AUTOINCREMENT NOT NULL, "file" varchar NOT NULL, "path" varchar NOT NULL, "bpm" integer NOT NULL, "title" varchar NOT NULL, "genre" varchar, "favorite" boolean NOT NULL DEFAULT (0), "hidden" boolean NOT NULL DEFAULT (0), "createdAt" datetime NOT NULL DEFAULT (CURRENT_TIMESTAMP), "modifiedAt" datetime NOT NULL, "scale" varchar, "notes" varchar, "progress" varchar NOT NULL DEFAULT ('to-do'), "daw" varchar NOT NULL, "tracks" json, "audioFile" varchar)`,
+      );
+    }
+    const settingTable = await queryRunner.getTable('setting');
+    if (!settingTable) {
+      await queryRunner.query(
+        `CREATE TABLE "setting" ("id" integer PRIMARY KEY AUTOINCREMENT NOT NULL, "key" varchar NOT NULL, "value" varchar)`,
+      );
+      // Seed settings
+      await queryRunner.query(
+        `INSERT INTO "setting" ("key", "value") VALUES ('projectsPath', NULL)`,
+      );
+      await queryRunner.query(
+        `INSERT INTO "setting" ("key", "value") VALUES ('theme', 'system')`,
+      );
+    }
+    const projectTagsTagTable = await queryRunner.getTable('project_tags_tag');
+    if (!projectTagsTagTable) {
+      await queryRunner.query(
+        `CREATE TABLE "project_tags_tag" ("projectId" integer NOT NULL, "tagId" integer NOT NULL, PRIMARY KEY ("projectId", "tagId"))`,
+      );
+    }
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`DROP TABLE "tag"`);
+    await queryRunner.query(`DROP TABLE "project_tags_tag"`);
+    await queryRunner.query(`DROP TABLE "setting"`);
+    await queryRunner.query(`DROP TABLE "project"`);
+  }
+}

--- a/src/db/migrations/1709996613942-SeedSettings.ts
+++ b/src/db/migrations/1709996613942-SeedSettings.ts
@@ -1,0 +1,31 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class SeedSettings1709996613942 implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    const projectsPath = await queryRunner.query(
+      `SELECT * FROM "setting" WHERE "key" = 'projectsPath'`,
+    );
+    console.log(projectsPath);
+
+    if (!projectsPath || !projectsPath.length) {
+      await queryRunner.query(
+        `INSERT INTO "setting" ("key", "value") VALUES ('projectsPath', NULL)`,
+      );
+    }
+    const theme = await queryRunner.query(
+      `SELECT * FROM "setting" WHERE "key" = 'theme'`,
+    );
+    if (!theme || !theme.length) {
+      await queryRunner.query(
+        `INSERT INTO "setting" ("key", "value") VALUES ('theme', 'system')`,
+      );
+    }
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `DELETE FROM "setting" WHERE "key" = 'projectsPath'`,
+    );
+    await queryRunner.query(`DELETE FROM "setting" WHERE "key" = 'theme'`);
+  }
+}


### PR DESCRIPTION
This commit adds two new migrations: one to create the database tables for
tags, projects, and settings, and another to seed default settings if they
do not already exist in the database. The `synchronize` option in the
`AppDataSource` configuration is set to `false` to prevent automatic schema
changes and ensure migrations are used instead.